### PR TITLE
Replace js_ffi with web.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/richardanaya/babylon"
 readme="README.md"
 
 [dependencies]
-js_ffi = "0.8.0"
 lazy_static = "1.4.0"
 globals = "1.0.1"
-nalgebra = "0.18"
+nalgebra = "0.32.2"
+web = "0.2.12"
+js = "0.5.7"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is pre-alpha and the api is in active exploration. Current prioriti
 * get a camera
 * get some sort of interaction
 
-This project uses [`js_ffi`](https://github.com/richardanaya/js_ffi) for javascript binding and [`lazy_static`](https://github.com/rust-lang-nursery/lazy-static.rs) for global static singletons fairly extensively.
+This project uses [`web`](https://github.com/richardanaya/web.rs) for javascript binding and [`lazy_static`](https://github.com/rust-lang-nursery/lazy-static.rs) for global static singletons fairly extensively.
 
 # Idioms
 * Scenes hold 3D objects

--- a/examples/gltf/index.html
+++ b/examples/gltf/index.html
@@ -21,14 +21,14 @@
             }
         </style>
 
-        <script src="https://cdn.jsdelivr.net/gh/richardanaya/js_ffi@latest/js_ffi.js"></script>
         <script src="https://preview.babylonjs.com/babylon.js"></script>
         <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-        <script src="https://code.jquery.com/pep/0.4.3/pep.js"></script>
     </head>
 
    <body>
         <canvas id="renderCanvas" touch-action="none"></canvas> <!-- touch-action="none" for best results from PEP -->
-   </body>
-    <script>js_ffi.run("example.wasm");</script>
+   
+        <script src="https://unpkg.com/js-wasm/js-wasm.js"></script>
+        <script type="application/wasm" src="example.wasm"></script>
+    </body>
 </html>

--- a/examples/helloworld/index.html
+++ b/examples/helloworld/index.html
@@ -21,14 +21,14 @@
             }
         </style>
 
-        <script src="https://cdn.jsdelivr.net/gh/richardanaya/js_ffi@latest/js_ffi.js"></script>
         <script src="https://preview.babylonjs.com/babylon.js"></script>
         <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-        <script src="https://code.jquery.com/pep/0.4.3/pep.js"></script>
     </head>
 
    <body>
         <canvas id="renderCanvas" touch-action="none"></canvas> <!-- touch-action="none" for best results from PEP -->
+        
+        <script src="https://unpkg.com/js-wasm/js-wasm.js"></script>
+        <script type="application/wasm" src="example.wasm"></script>
    </body>
-    <script>js_ffi.run("example.wasm");</script>
 </html>

--- a/examples/keyboard/index.html
+++ b/examples/keyboard/index.html
@@ -21,14 +21,14 @@
             }
         </style>
 
-        <script src="https://cdn.jsdelivr.net/gh/richardanaya/js_ffi@latest/js_ffi.js"></script>
         <script src="https://preview.babylonjs.com/babylon.js"></script>
         <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-        <script src="https://code.jquery.com/pep/0.4.3/pep.js"></script>
     </head>
 
    <body>
         <canvas id="renderCanvas" touch-action="none"></canvas> <!-- touch-action="none" for best results from PEP -->
+        
+        <script src="https://unpkg.com/js-wasm/js-wasm.js"></script>
+        <script type="application/wasm" src="example.wasm"></script>
    </body>
-    <script>js_ffi.run("example.wasm");</script>
 </html>

--- a/examples/materials/index.html
+++ b/examples/materials/index.html
@@ -21,14 +21,14 @@
             }
         </style>
 
-        <script src="https://cdn.jsdelivr.net/gh/richardanaya/js_ffi@latest/js_ffi.js"></script>
         <script src="https://preview.babylonjs.com/babylon.js"></script>
         <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-        <script src="https://code.jquery.com/pep/0.4.3/pep.js"></script>
     </head>
 
    <body>
         <canvas id="renderCanvas" touch-action="none"></canvas> <!-- touch-action="none" for best results from PEP -->
+    
+        <script src="https://unpkg.com/js-wasm/js-wasm.js"></script>
+        <script type="application/wasm" src="example.wasm"></script>
    </body>
-    <script>js_ffi.run("example.wasm");</script>
 </html>

--- a/examples/pong/index.html
+++ b/examples/pong/index.html
@@ -21,14 +21,14 @@
             }
         </style>
 
-        <script src="https://cdn.jsdelivr.net/gh/richardanaya/js_ffi@latest/js_ffi.js"></script>
         <script src="https://preview.babylonjs.com/babylon.js"></script>
         <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-        <script src="https://code.jquery.com/pep/0.4.3/pep.js"></script>
     </head>
 
    <body>
         <canvas id="renderCanvas" touch-action="none"></canvas> <!-- touch-action="none" for best results from PEP -->
+        
+        <script src="https://unpkg.com/js-wasm/js-wasm.js"></script>
+        <script type="application/wasm" src="example.wasm"></script>
    </body>
-    <script>js_ffi.run("example.wasm");</script>
 </html>

--- a/examples/pong/src/lib.rs
+++ b/examples/pong/src/lib.rs
@@ -54,31 +54,31 @@ impl BasicGame for Game {
         let bp = self.ball.get_position();
 
         // move ball
-        let b_x = self.ball_dir.x * delta_time + bp.x;
-        let b_y = self.ball_dir.y * delta_time + bp.y;
+        let mut b_x = self.ball_dir.x * delta_time + bp.x;
+        let mut b_y = self.ball_dir.y * delta_time + bp.y;
         if b_x > 0.5 || b_x < -0.5 {
             self.ball_dir.x = -self.ball_dir.x;
         }
-
         if b_y > 0.75 || b_y < -0.75 {
-            self.ball.set_position(Vector::new(0.0, 0.0, 0.0));
+            // Reset ball if outside play area
+            b_x = 0.0;
+            b_y = 0.0;
             self.ball_dir.x = babylon::js::random() - 0.5;
             self.ball_dir.y = -self.ball_dir.y;
-        } else if b_y > 0.45 || (b_y < -0.45 && b_x <= p2.x + 0.25 && b_x >= p2.x - 0.25) {
+        } else if b_y > 0.45 || (b_y < -0.45 && b_y > -0.55 && b_x <= p2.x + 0.25 && b_x >= p2.x - 0.25) {
+            // Hit paddle (top paddle is assumed to always hit)
             self.ball_dir.y = -self.ball_dir.y;
-            self.ball.set_position(Vector::new(b_x, b_y, 0.0));
-        } else {
-            self.ball.set_position(Vector::new(b_x, b_y, 0.0));
+            b_y = if b_y > 0.0 { 0.44 } else { -0.44 };
         }
-
+        
+        self.ball.set_position(Vector::new(b_x, b_y, 0.0));
+        
         // move opponent paddle to match ball
         self.paddle_1.set_position_x(b_x);
 
         // move paddle if it has velocity
-        if self.paddle_dir != 0.0 {
-            let p2_x = p2.x + delta_time * self.paddle_dir;
-            self.paddle_2.set_position_x(p2_x)
-        }
+        let p2_x = p2.x + delta_time * self.paddle_dir;
+        self.paddle_2.set_position_x(p2_x);
     }
 
     fn key_up(&mut self, _key_code: f64) {
@@ -86,10 +86,10 @@ impl BasicGame for Game {
     }
 
     fn key_down(&mut self, key_code: f64) {
-        if key_code == 37.0 {
-            self.paddle_dir = 1.0;
-        } else if key_code == 39.0 {
-            self.paddle_dir = -1.0;
+        match key_code {
+            37.0 => self.paddle_dir = 1.0,
+            39.0 => self.paddle_dir = -1.0,
+            _ => {}
         }
     }
 }

--- a/examples/timer/index.html
+++ b/examples/timer/index.html
@@ -21,14 +21,14 @@
             }
         </style>
 
-        <script src="https://cdn.jsdelivr.net/gh/richardanaya/js_ffi@latest/js_ffi.js"></script>
         <script src="https://preview.babylonjs.com/babylon.js"></script>
         <script src="https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-        <script src="https://code.jquery.com/pep/0.4.3/pep.js"></script>
     </head>
 
    <body>
         <canvas id="renderCanvas" touch-action="none"></canvas> <!-- touch-action="none" for best results from PEP -->
+        
+        <script src="https://unpkg.com/js-wasm/js-wasm.js"></script>
+        <script type="application/wasm" src="example.wasm"></script>
    </body>
-    <script>js_ffi.run("example.wasm");</script>
 </html>

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,39 +1,39 @@
 use alloc::boxed::Box;
-use js_ffi::*;
+use web::*;
 
 pub struct BabylonApi {
-    fn_log: JSInvoker,
-    fn_error: JSInvoker,
-    fn_debug: JSInvoker,
-    fn_random: JSInvoker,
-    fn_create_basic_scene: JSInvoker,
-    fn_create_scene: JSInvoker,
-    fn_create_sphere: JSInvoker,
-    fn_create_cube: JSInvoker,
-    fn_create_standard_material: JSInvoker,
-    fn_dispose_mesh: JSInvoker,
-    fn_set_position: JSInvoker,
-    fn_set_scaling: JSInvoker,
-    fn_set_material: JSInvoker,
-    fn_set_emmisive_color: JSInvoker,
-    fn_set_diffuse_color: JSInvoker,
-    fn_set_specular_color: JSInvoker,
-    fn_set_ambient_color: JSInvoker,
-    fn_set_clear_color: JSInvoker,
-    fn_set_alpha: JSInvoker,
-    fn_add_keyboard_observable: JSInvoker,
-    fn_add_observable: JSInvoker,
-    fn_get_delta_time: JSInvoker,
-    fn_create_arc_rotate_camera: JSInvoker,
-    fn_create_hemispheric_light: JSInvoker,
-    fn_create_point_light: JSInvoker,
-    fn_create_gltf: JSInvoker,
+    fn_log: JSFunction,
+    fn_error: JSFunction,
+    fn_debug: JSFunction,
+    fn_random: JSFunction,
+    fn_create_basic_scene: JSFunction,
+    fn_create_scene: JSFunction,
+    fn_create_sphere: JSFunction,
+    fn_create_cube: JSFunction,
+    fn_create_standard_material: JSFunction,
+    fn_dispose_mesh: JSFunction,
+    fn_set_position: JSFunction,
+    fn_set_scaling: JSFunction,
+    fn_set_material: JSFunction,
+    fn_set_emmisive_color: JSFunction,
+    fn_set_diffuse_color: JSFunction,
+    fn_set_specular_color: JSFunction,
+    fn_set_ambient_color: JSFunction,
+    fn_set_clear_color: JSFunction,
+    fn_set_alpha: JSFunction,
+    fn_add_keyboard_observable: JSFunction,
+    fn_add_observable: JSFunction,
+    fn_get_delta_time: JSFunction,
+    fn_create_arc_rotate_camera: JSFunction,
+    fn_create_hemispheric_light: JSFunction,
+    fn_create_point_light: JSFunction,
+    fn_create_gltf: JSFunction,
 }
 
 impl Default for BabylonApi {
     fn default() -> Self {
         BabylonApi {
-            fn_create_basic_scene: register_function(
+            fn_create_basic_scene: js!(
                 r#"
                 function(selector){
                     var canvas = document.querySelector(selector);
@@ -79,9 +79,9 @@ impl Default for BabylonApi {
                     });
                     return scene;
                 }
-            "#,
+            "#
             ),
-            fn_create_scene: register_function(
+            fn_create_scene: js!(
                 r#"
                 function(selector){
                     var canvas = document.querySelector(selector);
@@ -99,9 +99,9 @@ impl Default for BabylonApi {
                     });
                     return scene;
                 }
-            "#,
+            "#
             ),
-            fn_create_sphere: register_function(
+            fn_create_sphere: js!(
                 r#"
                 function(scene,size){
                     return BABYLON.MeshBuilder.CreateSphere(
@@ -109,9 +109,9 @@ impl Default for BabylonApi {
                         { diameter: size },
                         scene);
                 }
-            "#,
+            "#
             ),
-            fn_create_cube: register_function(
+            fn_create_cube: js!(
                 r#"
                 function(scene,w,h,d){
                     return BABYLON.MeshBuilder.CreateBox(
@@ -119,139 +119,139 @@ impl Default for BabylonApi {
                         { height: h, width: w, depth: d },
                         scene);
                 }
-            "#,
+            "#
             ),
-            fn_create_standard_material: register_function(
+            fn_create_standard_material: js!(
                 r#"
                 function(scene){
                     return new BABYLON.StandardMaterial(null, scene);
                 }
-            "#,
+            "#
             ),
-            fn_dispose_mesh: register_function(
+            fn_dispose_mesh: js!(
                 r#"
                 function(mesh){
                     mesh.dispose()
                 }
-            "#,
+            "#
             ),
-            fn_log: register_function(
+            fn_log: js!(
                 r#"
                 function(msg){
                     console.log(msg);
                 }
-            "#,
+            "#
             ),
-            fn_error: register_function(
+            fn_error: js!(
                 r#"
                 function(msg){
                     console.error(msg);
                 }
-            "#,
+            "#
             ),
-            fn_debug: register_function(
+            fn_debug: js!(
                 r#"
                 function(){
                     debugger;
                 }
-            "#,
+            "#
             ),
-            fn_random: register_function(
+            fn_random: js!(
                 r#"
                 function(){
                     return Math.random();
                 }
-            "#,
+            "#
             ),
-            fn_set_position: register_function(
+            fn_set_position: js!(
                 r#"
                 function(mesh,x,y,z){
                     mesh.position = new BABYLON.Vector3(x,y,z);
                 }
-            "#,
+            "#
             ),
-            fn_set_scaling: register_function(
+            fn_set_scaling: js!(
                 r#"
                 function(mesh,x,y,z){
                     mesh.scaling = new BABYLON.Vector3(x,y,z);
                 }
-            "#,
+            "#
             ),
-            fn_set_material: register_function(
+            fn_set_material: js!(
                 r#"
                 function(mesh,mat){
                     mesh.material = mat;
                 }
-            "#,
+            "#
             ),
-            fn_set_emmisive_color: register_function(
+            fn_set_emmisive_color: js!(
                 r#"
                 function(mat,r,g,b){
                     mat.emissiveColor = new BABYLON.Color3(r, g, b);
                 }
-            "#,
+            "#
             ),
-            fn_set_diffuse_color: register_function(
+            fn_set_diffuse_color: js!(
                 r#"
                 function(mat,r,g,b){
                     mat.diffuseColor = new BABYLON.Color3(r, g, b);
                 }
-            "#,
+            "#
             ),
-            fn_set_specular_color: register_function(
+            fn_set_specular_color: js!(
                 r#"
                 function(mat,r,g,b){
                     mat.specularColor = new BABYLON.Color3(r, g, b);
                 }
-            "#,
+            "#
             ),
-            fn_set_ambient_color: register_function(
+            fn_set_ambient_color: js!(
                 r#"
                 function(mat,r,g,b){
                     mat.ambientColor = new BABYLON.Color3(r, g, b);
                 }
-            "#,
+            "#
             ),
-            fn_set_clear_color: register_function(
+            fn_set_clear_color: js!(
                 r#"
                 function(scene,r,g,b){
                     scene.clearColor = new BABYLON.Color3(r, g, b);
                 }
-            "#,
+            "#
             ),
-            fn_set_alpha: register_function(
+            fn_set_alpha: js!(
                 r#"
                 function(mat,a){
                     mat.alpha = a;
                 }
-            "#,
+            "#
             ),
-            fn_add_keyboard_observable: register_function(
+            fn_add_keyboard_observable: js!(
                 r#"
                 function(scene,cb){
                     scene.onKeyboardObservable.add((kbInfo) => {
                         cb(kbInfo.type,kbInfo.event.keyCode)
                     });
                 }
-            "#,
+            "#
             ),
-            fn_add_observable: register_function(
+            fn_add_observable: js!(
                 r#"
                 function(scene,name,cb){
                     scene[name].add(() => {
                         cb()
                     });
                 }
-            "#,
+            "#
             ),
-            fn_get_delta_time: register_function(
+            fn_get_delta_time: js!(
                 r#"
                 function(scene){
                     return scene.getEngine().getDeltaTime();
                 }
-            "#,
+            "#
             ),
-            fn_create_arc_rotate_camera: register_function(
+            fn_create_arc_rotate_camera: js!(
                 r#"
                 function(scene){
                     var camera = new BABYLON.ArcRotateCamera(
@@ -264,9 +264,9 @@ impl Default for BabylonApi {
                     );
                     return camera;
                 }
-            "#,
+            "#
             ),
-            fn_create_hemispheric_light: register_function(
+            fn_create_hemispheric_light: js!(
                 r#"
                 function(scene){
                     var light = new BABYLON.HemisphericLight(
@@ -276,9 +276,9 @@ impl Default for BabylonApi {
                     );
                     return light;
                 }
-            "#,
+            "#
             ),
-            fn_create_point_light: register_function(
+            fn_create_point_light: js!(
                 r#"
                 function(scene){
                     var light = new BABYLON.PointLight(
@@ -288,173 +288,167 @@ impl Default for BabylonApi {
                     );
                     return light;
                 }
-            "#,
+            "#
             ),
-            fn_create_gltf: register_function(
+            fn_create_gltf: js!(
                 r#"
                 function(scene,file){
                     var dummy = new BABYLON.Mesh(null, scene);
                     BABYLON.SceneLoader.ImportMesh(null, "", file, scene, function (newMeshes, particleSystems, skeletons) {
-                        for(v in newMeshes){
+                        for(let v in newMeshes){
                             var dude = newMeshes[v];
                             dude.parent = dummy;
                         }
                     });
                     return dummy;
                 }
-                "#,
+                "#
             ),
         }
     }
 }
 
 impl BabylonApi {
-    pub fn create_basic_scene(selector: &str) -> JSObject {
+    pub fn create_basic_scene(selector: &str) -> ExternRef {
         let api = globals::get::<BabylonApi>();
-        api.fn_create_basic_scene.invoke_1(selector).to_js_object()
+        api.fn_create_basic_scene.invoke_and_return_object(&[InvokeParam::String(selector)])
     }
-    pub fn create_scene(selector: &str) -> JSObject {
+    pub fn create_scene(selector: &str) -> ExternRef {
         let api = globals::get::<BabylonApi>();
-        api.fn_create_scene.invoke_1(selector).to_js_object()
+        api.fn_create_scene.invoke_and_return_object(&[InvokeParam::String(selector)])
     }
-    pub fn create_sphere(scene_ref: &JSObject, size: f64) -> JSObject {
+    pub fn create_sphere(scene_ref: &ExternRef, size: f64) -> ExternRef {
         let api = globals::get::<BabylonApi>();
         api.fn_create_sphere
-            .invoke_2(scene_ref, size)
-            .to_js_object()
+            .invoke_and_return_object(&[InvokeParam::ExternRef(scene_ref), InvokeParam::Float64(size)])
     }
 
-    pub fn create_cube(scene_ref: &JSObject, width: f64, height: f64, depth: f64) -> JSObject {
+    pub fn create_cube(scene_ref: &ExternRef, width: f64, height: f64, depth: f64) -> ExternRef {
         let api = globals::get::<BabylonApi>();
         api.fn_create_cube
-            .invoke_4(scene_ref, width, height, depth)
-            .to_js_object()
+            .invoke_and_return_object(&[InvokeParam::ExternRef(scene_ref), InvokeParam::Float64(width), InvokeParam::Float64(height), InvokeParam::Float64(depth)])
     }
 
-    pub fn create_standard_material(scene_ref: &JSObject) -> JSObject {
+    pub fn create_standard_material(scene_ref: &ExternRef) -> ExternRef {
         let api = globals::get::<BabylonApi>();
         api.fn_create_standard_material
-            .invoke_1(scene_ref)
-            .to_js_object()
+            .invoke_and_return_object(&[InvokeParam::ExternRef(scene_ref)])
     }
 
-    pub fn dispose_mesh(mesh: &JSObject) {
+    pub fn dispose_mesh(mesh: &ExternRef) {
         let api = globals::get::<BabylonApi>();
-        api.fn_dispose_mesh.invoke_1(mesh);
+        api.fn_dispose_mesh.invoke(&[InvokeParam::ExternRef(mesh)]);
     }
 
     pub fn log(msg: &str) {
         let api = globals::get::<BabylonApi>();
-        api.fn_log.invoke_1(msg);
+        api.fn_log.invoke(&[InvokeParam::String(msg)]);
     }
 
     pub fn error(msg: &str) {
         let api = globals::get::<BabylonApi>();
-        api.fn_error.invoke_1(msg);
+        api.fn_error.invoke(&[InvokeParam::String(msg)]);
     }
 
     pub fn debugger() {
         let api = globals::get::<BabylonApi>();
-        api.fn_debug.invoke_0();
+        api.fn_debug.invoke(&[]);
     }
 
     pub fn random() -> f64 {
         let api = globals::get::<BabylonApi>();
-        api.fn_random.invoke_0()
+        api.fn_random.invoke(&[])
     }
 
-    pub fn set_position(mesh: &JSObject, x: f64, y: f64, z: f64) {
+    pub fn set_position(mesh: &ExternRef, x: f64, y: f64, z: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_position.invoke_4(mesh, x, y, z);
+        api.fn_set_position.invoke(&[InvokeParam::ExternRef(mesh), InvokeParam::Float64(x), InvokeParam::Float64(y), InvokeParam::Float64(z)]);
     }
 
-    pub fn set_scaling(mesh: &JSObject, x: f64, y: f64, z: f64) {
+    pub fn set_scaling(mesh: &ExternRef, x: f64, y: f64, z: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_scaling.invoke_4(mesh, x, y, z);
+        api.fn_set_scaling.invoke(&[InvokeParam::ExternRef(mesh), InvokeParam::Float64(x), InvokeParam::Float64(y), InvokeParam::Float64(z)]);
     }
 
-    pub fn set_material(mesh: &JSObject, mat: &JSObject) {
+    pub fn set_material(mesh: &ExternRef, mat: &ExternRef) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_material.invoke_2(mesh, mat);
+        api.fn_set_material.invoke(&[InvokeParam::ExternRef(mesh), InvokeParam::ExternRef(mat)]);
     }
 
-    pub fn set_emmisive_color(mat: &JSObject, r: f64, g: f64, b: f64) {
+    pub fn set_emmisive_color(mat: &ExternRef, r: f64, g: f64, b: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_emmisive_color.invoke_4(mat, r, g, b);
+        api.fn_set_emmisive_color.invoke(&[InvokeParam::ExternRef(mat), InvokeParam::Float64(r), InvokeParam::Float64(g), InvokeParam::Float64(b)]);
     }
 
-    pub fn set_diffuse_color(mat: &JSObject, r: f64, g: f64, b: f64) {
+    pub fn set_diffuse_color(mat: &ExternRef, r: f64, g: f64, b: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_diffuse_color.invoke_4(mat, r, g, b);
+        api.fn_set_diffuse_color.invoke(&[InvokeParam::ExternRef(mat), InvokeParam::Float64(r), InvokeParam::Float64(g), InvokeParam::Float64(b)]);
     }
 
-    pub fn set_specular_color(mat: &JSObject, r: f64, g: f64, b: f64) {
+    pub fn set_specular_color(mat: &ExternRef, r: f64, g: f64, b: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_specular_color.invoke_4(mat, r, g, b);
+        api.fn_set_specular_color.invoke(&[InvokeParam::ExternRef(mat), InvokeParam::Float64(r), InvokeParam::Float64(g), InvokeParam::Float64(b)]);
     }
 
-    pub fn set_ambient_color(mat: &JSObject, r: f64, g: f64, b: f64) {
+    pub fn set_ambient_color(mat: &ExternRef, r: f64, g: f64, b: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_ambient_color.invoke_4(mat, r, g, b);
+        api.fn_set_ambient_color.invoke(&[InvokeParam::ExternRef(mat), InvokeParam::Float64(r), InvokeParam::Float64(g), InvokeParam::Float64(b)]);
     }
 
-    pub fn set_clear_color(mat: &JSObject, r: f64, g: f64, b: f64) {
+    pub fn set_clear_color(mat: &ExternRef, r: f64, g: f64, b: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_clear_color.invoke_4(mat, r, g, b);
+        api.fn_set_clear_color.invoke(&[InvokeParam::ExternRef(mat), InvokeParam::Float64(r), InvokeParam::Float64(g), InvokeParam::Float64(b)]);
     }
 
-    pub fn set_alpha(mat: &JSObject, a: f64) {
+    pub fn set_alpha(mat: &ExternRef, a: f64) {
         let api = globals::get::<BabylonApi>();
-        api.fn_set_alpha.invoke_2(mat, a);
+        api.fn_set_alpha.invoke(&[InvokeParam::ExternRef(mat), InvokeParam::Float64(a)]);
     }
 
     pub fn add_keyboard_observable(
-        scene: &JSObject,
-        callback: Box<dyn FnMut(JSValue, JSValue) -> () + Send>,
+        scene: &ExternRef,
+        callback: Box<dyn FnMut(f64, f64) -> () + Send>,
     ) {
-        let cb = create_callback_2(callback);
+        /*let cb = callback;
         let api = globals::get::<BabylonApi>();
-        api.fn_add_keyboard_observable.invoke_2(scene, cb);
+        api.fn_add_keyboard_observable.invoke(&[InvokeParam::ExternRef(scene), InvokeParam::ExternRef(cb)]);*/
     }
 
     pub fn add_observable(
-        scene: &JSObject,
+        scene: &ExternRef,
         observable_name: &str,
         callback: Box<dyn FnMut() -> () + Send>,
     ) {
-        let cb = create_callback_0(callback);
+        /*let cb = create_callback(callback);
         let api = globals::get::<BabylonApi>();
-        api.fn_add_observable.invoke_3(scene, observable_name, cb);
+        api.fn_add_observable.invoke(&[InvokeParam::ExternRef(scene), InvokeParam::String(observable_name),  cb]);*/
     }
 
-    pub fn get_delta_time(scene: &JSObject) -> f64 {
+    pub fn get_delta_time(scene: &ExternRef) -> f64 {
         let api = globals::get::<BabylonApi>();
-        api.fn_get_delta_time.invoke_1(scene)
+        api.fn_get_delta_time.invoke(&[InvokeParam::ExternRef(scene)])
     }
 
-    pub fn create_arc_rotate_camera(scene: &JSObject) -> JSObject {
+    pub fn create_arc_rotate_camera(scene: &ExternRef) -> ExternRef {
         let api = globals::get::<BabylonApi>();
         api.fn_create_arc_rotate_camera
-            .invoke_1(scene)
-            .to_js_object()
+            .invoke_and_return_object(&[InvokeParam::ExternRef(scene)])
     }
 
-    pub fn create_hemispheric_light(scene: &JSObject) -> JSObject {
+    pub fn create_hemispheric_light(scene: &ExternRef) -> ExternRef {
         let api = globals::get::<BabylonApi>();
         api.fn_create_hemispheric_light
-            .invoke_1(scene)
-            .to_js_object()
+            .invoke_and_return_object(&[InvokeParam::ExternRef(scene)])
     }
 
-    pub fn create_point_light(scene: &JSObject) -> JSObject {
+    pub fn create_point_light(scene: &ExternRef) -> ExternRef {
         let api = globals::get::<BabylonApi>();
-        api.fn_create_point_light.invoke_1(scene).to_js_object()
+        api.fn_create_point_light.invoke_and_return_object(&[InvokeParam::ExternRef(scene)])
     }
 
-    pub fn create_gltf(scene: &JSObject, file: &str) -> JSObject {
+    pub fn create_gltf(scene: &ExternRef, file: &str) -> ExternRef {
         let api = globals::get::<BabylonApi>();
         api.fn_create_gltf
-            .invoke_2(scene, file)
-            .to_js_object()
+            .invoke_and_return_object(&[InvokeParam::ExternRef(scene), InvokeParam::String(file)])
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,3 @@
-use alloc::boxed::Box;
 use web::*;
 
 pub struct BabylonApi {
@@ -230,7 +229,7 @@ impl Default for BabylonApi {
                 r#"
                 function(scene,cb){
                     scene.onKeyboardObservable.add((kbInfo) => {
-                        cb(kbInfo.type,kbInfo.event.keyCode)
+                        this.module.instance.exports[cb](kbInfo.type,kbInfo.event.keyCode)
                     });
                 }
             "#
@@ -239,7 +238,7 @@ impl Default for BabylonApi {
                 r#"
                 function(scene,name,cb){
                     scene[name].add(() => {
-                        cb()
+                        this.module.instance.exports[cb]()
                     });
                 }
             "#
@@ -407,21 +406,19 @@ impl BabylonApi {
 
     pub fn add_keyboard_observable(
         scene: &ExternRef,
-        callback: Box<dyn FnMut(f64, f64) -> () + Send>,
+        callback: &str
     ) {
-        /*let cb = callback;
         let api = globals::get::<BabylonApi>();
-        api.fn_add_keyboard_observable.invoke(&[InvokeParam::ExternRef(scene), InvokeParam::ExternRef(cb)]);*/
+        api.fn_add_keyboard_observable.invoke(&[InvokeParam::ExternRef(scene), InvokeParam::String(callback)]);
     }
 
     pub fn add_observable(
         scene: &ExternRef,
         observable_name: &str,
-        callback: Box<dyn FnMut() -> () + Send>,
+        callback: &str
     ) {
-        /*let cb = create_callback(callback);
         let api = globals::get::<BabylonApi>();
-        api.fn_add_observable.invoke(&[InvokeParam::ExternRef(scene), InvokeParam::String(observable_name),  cb]);*/
+        api.fn_add_observable.invoke(&[InvokeParam::ExternRef(scene), InvokeParam::String(observable_name), InvokeParam::String(callback)]);
     }
 
     pub fn get_delta_time(scene: &ExternRef) -> f64 {

--- a/src/basic_game.rs
+++ b/src/basic_game.rs
@@ -20,25 +20,31 @@ where
     let mut game = GAME.lock().unwrap();
     let t = T::default();
     let scene = t.get_scene();
-    scene.add_before_render_observable(|| {
-        let mut game = GAME.lock().unwrap();
-        if let Some(g) = &mut *game {
-            let scene = g.get_scene();
-            let delta_time = scene.get_delta_time();
-            g.run(delta_time / 1000.0);
-        }
-    });
-    scene.add_keyboard_observable(|event_type, key_code| {
-        let mut game = GAME.lock().unwrap();
-        if let Some(g) = &mut *game {
-            if event_type == KEYDOWN {
-                g.key_down(key_code);
-            }
-            if event_type == KEYUP {
-                g.key_up(key_code);
-            }
-        }
-    });
+    scene.add_before_render_observable("basic_game_before_render_observer");
+    scene.add_keyboard_observable("basic_game_keyboard_observer");
 
     *game = Some(Box::new(t));
+}
+
+#[no_mangle]
+fn basic_game_before_render_observer() {
+    let mut game = GAME.lock().unwrap();
+    if let Some(g) = &mut *game {
+        let scene = g.get_scene();
+        let delta_time = scene.get_delta_time();
+        g.run(delta_time / 1000.0);
+    }
+}
+
+#[no_mangle]
+fn basic_game_keyboard_observer(event_type: f64, key_code: f64) {
+    let mut game = GAME.lock().unwrap();
+    if let Some(g) = &mut *game {
+        if event_type == KEYDOWN {
+            g.key_down(key_code);
+        }
+        if event_type == KEYUP {
+            g.key_up(key_code);
+        }
+    }
 }

--- a/src/cameras.rs
+++ b/src/cameras.rs
@@ -1,9 +1,9 @@
 use crate::api::BabylonApi;
 use crate::core::Scene;
-use js_ffi::*;
+use web::*;
 
 pub struct Camera {
-    _js_ref: JSObject,
+    _js_ref: ExternRef,
 }
 
 impl Camera {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,2 @@
-use js_ffi::*;
-
-pub const KEYDOWN: JSValue = 1.0;
-pub const KEYUP: JSValue = 2.0;
+pub const KEYDOWN: f64 = 1.0;
+pub const KEYUP: f64 = 2.0;

--- a/src/core.rs
+++ b/src/core.rs
@@ -59,9 +59,3 @@ impl Scene {
         BabylonApi::set_clear_color(self.get_js_ref(), c.x, c.y, c.z);
     }
 }
-
-impl Drop for Scene {
-    fn drop(&mut self) {
-        //release_object(&self.scene_ref)
-    }
-}

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,12 +1,12 @@
 use crate::api::BabylonApi;
 use crate::math::*;
 use alloc::boxed::Box;
-use js_ffi::*;
+use web::*;
 
 pub struct Scene {
     ambient_color: Color,
     clear_color: Color,
-    scene_ref: JSObject,
+    scene_ref: ExternRef,
 }
 
 impl Scene {
@@ -28,13 +28,13 @@ impl Scene {
         }
     }
 
-    pub fn get_js_ref(&self) -> &JSObject {
+    pub fn get_js_ref(&self) -> &ExternRef {
         &self.scene_ref
     }
 
     pub fn add_keyboard_observable<T>(&self, callback: T)
     where
-        T: 'static + FnMut(JSValue, JSValue) -> () + Send,
+        T: 'static + FnMut(f64, f64) -> () + Send,
     {
         BabylonApi::add_keyboard_observable(&self.scene_ref, Box::new(callback));
     }
@@ -67,6 +67,6 @@ impl Scene {
 
 impl Drop for Scene {
     fn drop(&mut self) {
-        release_object(&self.scene_ref)
+        //release_object(&self.scene_ref)
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,5 @@
 use crate::api::BabylonApi;
 use crate::math::*;
-use alloc::boxed::Box;
 use web::*;
 
 pub struct Scene {
@@ -32,21 +31,17 @@ impl Scene {
         &self.scene_ref
     }
 
-    pub fn add_keyboard_observable<T>(&self, callback: T)
-    where
-        T: 'static + FnMut(f64, f64) -> () + Send,
+    pub fn add_keyboard_observable(&self, callback: &str)
     {
-        BabylonApi::add_keyboard_observable(&self.scene_ref, Box::new(callback));
+        BabylonApi::add_keyboard_observable(&self.scene_ref, callback);
     }
 
-    pub fn add_before_render_observable<T>(&self, callback: T)
-    where
-        T: 'static + FnMut() -> () + Send,
+    pub fn add_before_render_observable(&self, callback: &str)
     {
         BabylonApi::add_observable(
             &self.scene_ref,
             "onBeforeRenderObservable",
-            Box::new(callback),
+            callback,
         );
     }
 

--- a/src/lights.rs
+++ b/src/lights.rs
@@ -1,9 +1,9 @@
 use crate::api::BabylonApi;
 use crate::core::Scene;
-use js_ffi::*;
+use web::*;
 
 pub struct HemisphericLight {
-    _js_ref: JSObject,
+    _js_ref: ExternRef,
 }
 
 impl HemisphericLight {
@@ -15,7 +15,7 @@ impl HemisphericLight {
 }
 
 pub struct PointLight {
-    _js_ref: JSObject,
+    _js_ref: ExternRef,
 }
 
 impl PointLight {

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -1,14 +1,14 @@
 use crate::api::BabylonApi;
 use crate::core::*;
 use crate::math::*;
-use js_ffi::*;
+use web::*;
 
 pub trait Material {
-    fn get_js_ref(&self) -> &JSObject;
+    fn get_js_ref(&self) -> &ExternRef;
 }
 
 pub struct StandardMaterial {
-    js_ref: JSObject,
+    js_ref: ExternRef,
     diffuse_color: Color,
     specular_color: Color,
     emmisive_color: Color,
@@ -55,7 +55,7 @@ impl StandardMaterial {
 }
 
 impl Material for StandardMaterial {
-    fn get_js_ref(&self) -> &JSObject {
+    fn get_js_ref(&self) -> &ExternRef {
         return &self.js_ref;
     }
 }

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -72,7 +72,6 @@ impl Sphere {
 impl Drop for Sphere {
     fn drop(&mut self) {
         BabylonApi::dispose_mesh(&mut self.js_ref);
-        //release_object(&self.js_ref)
     }
 }
 
@@ -139,7 +138,6 @@ impl Cube {
 impl Drop for Cube {
     fn drop(&mut self) {
         BabylonApi::dispose_mesh(&mut self.js_ref);
-        //release_object(&self.js_ref)
     }
 }
 
@@ -204,6 +202,5 @@ impl GLTF {
 impl Drop for GLTF {
     fn drop(&mut self) {
         BabylonApi::dispose_mesh(&mut self.js_ref);
-        //release_object(&self.js_ref)
     }
 }

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -2,11 +2,11 @@ use crate::api::BabylonApi;
 use crate::core::*;
 use crate::materials::*;
 use crate::math::*;
-use js_ffi::*;
+use web::*;
 
 pub struct Sphere {
     position: Vector3<f64>,
-    js_ref: JSObject,
+    js_ref: ExternRef,
 }
 
 impl Sphere {
@@ -72,13 +72,13 @@ impl Sphere {
 impl Drop for Sphere {
     fn drop(&mut self) {
         BabylonApi::dispose_mesh(&mut self.js_ref);
-        release_object(&self.js_ref)
+        //release_object(&self.js_ref)
     }
 }
 
 pub struct Cube {
     position: Vector3<f64>,
-    js_ref: JSObject,
+    js_ref: ExternRef,
 }
 
 impl Cube {
@@ -139,13 +139,13 @@ impl Cube {
 impl Drop for Cube {
     fn drop(&mut self) {
         BabylonApi::dispose_mesh(&mut self.js_ref);
-        release_object(&self.js_ref)
+        //release_object(&self.js_ref)
     }
 }
 
 pub struct GLTF {
     position: Vector3<f64>,
-    js_ref: JSObject,
+    js_ref: ExternRef,
 }
 
 impl GLTF {
@@ -204,6 +204,6 @@ impl GLTF {
 impl Drop for GLTF {
     fn drop(&mut self) {
         BabylonApi::dispose_mesh(&mut self.js_ref);
-        release_object(&self.js_ref)
+        //release_object(&self.js_ref)
     }
 }


### PR DESCRIPTION
I want to use this for a project, but saw `js_ffi` was obsolete'd. This is a working modification using `web` instead, but there might be a few changes required still.

Things I wasn't clear about: 
 - Callbacks added as `this.module.instance.exports[callback]` vs HashMap of callback functions with IDs
 - ~~Replacing `release_object`~~